### PR TITLE
Updates the PercentService example in communication_ports and processes files

### DIFF
--- a/documentation/basics/communication_ports/a_comprehensive_example.md
+++ b/documentation/basics/communication_ports/a_comprehensive_example.md
@@ -70,14 +70,12 @@ inputPort PercService {
 
 execution{ concurrent }
 
-init {
-    install( TypeMismatch =>
-                println@Console( "TypeMismatch: " + main.TypeMismatch )()
-    )
-}
-
 main
 {
+    install( TypeMismatch =>
+        println@Console( "TypeMismatch: " + main.TypeMismatch )()
+    );
+
     percent( request )( response ){
         response.percent_value = double( request.part )/request.total
     }
@@ -88,6 +86,6 @@ The programs can be downloaded from the link below:
 
 <div class="download"><a href="/documentation/basics/code/communication_ports_code.zip">Communication Ports Code Example</a></div>
 
-Once extracted, the two programs may be run in two separate shells. Make sure to start `server.ol` before `client.ol`. 
+Once extracted, the two programs may be run in two separate shells. Make sure to start `server.ol` before `client.ol`.
 
 Note the presence of two definitions, respectively at Lines 12-15 and Lines 17-18 in client's source code. Both of these procedures set the values of `request.total` and `request.part` in the request message. By switching the comment from Line 27 to 28 and viceversa the invocation of `percent` operation is successful or returns a `TypeMismatch` error.

--- a/documentation/basics/processes.md
+++ b/documentation/basics/processes.md
@@ -29,12 +29,15 @@ inputPort PercService {
 
 execution{ concurrent }
 
-main
+init
 {
 	install( TypeMismatch =>
-				println@Console( "TypeMismatch: " + main.TypeMismatch )()
-	);
+		println@Console( "TypeMismatch: " + main.TypeMismatch )()
+	)
+}
 
+main
+{
 	percent( request )( response ){
 		response.percent_value = double( request.part )/request.total
 	}
@@ -59,14 +62,14 @@ myLocalVariable = 1 // Local to this behaviour instance
 
 ---
 
-## Synchronisation 
+## Synchronisation
 
 Concurrent access to global variables can be restricted through `synchronized` blocks, similarly to Java:
 
 <pre class="syntax">
 synchronized( id ){
 	//code
-} 
+}
 </pre>
 
 The synchronisation block allows only one process at a time to enter any `synchronized` block sharing the same `id`.
@@ -75,7 +78,7 @@ The synchronisation block allows only one process at a time to enter any `synchr
 
 ## A comprehensive example
 
-Let us consider a comprehensive example using the concepts explained in this section. 
+Let us consider a comprehensive example using the concepts explained in this section.
 
 The register service has a concurrent execution and exposes the `register` request-response operation. `register` increments a global variable, which counts the number of registered users, and sends back a response to the client.
 
@@ -102,13 +105,13 @@ inputPort Register {
 
 execution { concurrent }
 
-init 
-{	
+init
+{
 	global.registered_users=0;
 	response.message = "Successful registration.nYou are the user number "
 }
 
-main 
+main
 {
 	register()( response ){
 		synchronized( syncToken ) {
@@ -129,7 +132,7 @@ outputPort Register {
 	Interfaces: RegService
 }
 
-main 
+main
 {
 	register@Register()( response );
 	println@Console( response.message )()


### PR DESCRIPTION
Hi guys,

The PercentService example has recently been updated to move the `setup` statement from `main` to `init` procedure, but the change was in the wrong file.

Cheers,
João Fernandes