### PR TITLE
Mauro's proposal changes

### DIFF
--- a/web/language-tools-and-standard-library/basics/constants.md
+++ b/web/language-tools-and-standard-library/basics/constants.md
@@ -25,3 +25,14 @@ Constants might also be assigned on the command line. Just call a program using 
 
 **Attention.** Under Windows `=` is a parameter delimiter. To correctly use the command line option `-C` make sure to enclose the assignment of the constant between single or double quotes like `jolie -C "server_location=\"socket://localhost:4003\"" program.ol` .
 
+# Comments
+
+The comments' format is the same as in Java:
+```
+// single line
+
+/*
+multiple 
+lines
+*/
+```

--- a/web/language-tools-and-standard-library/basics/data_structures.md
+++ b/web/language-tools-and-standard-library/basics/data_structures.md
@@ -183,6 +183,25 @@ A structure can be completely erased - undefined - using the statement `undef`:
 ```jolie
 undef( animals )
 ```
+**WARNING:**
+undef ( ) do not remove the structure it is aliasing, only undefine the alias used.
+
+For example
+```
+include "console.iol"
+
+main {
+    a.b.c.d.e = 12;
+    a.b.c = 14;
+    p -> a.b.c;
+    println@Console(p)();
+    undef(p);
+    println@Console(a.b.c)();
+    println@Console(a.b.c.d.e)()
+}
+```
+
+running the code shows, that after the operation undef on p, the original data path is unchanged.
 
 ## `<<` - copying an entire tree structure
 

--- a/web/language-tools-and-standard-library/basics/data_structures.md
+++ b/web/language-tools-and-standard-library/basics/data_structures.md
@@ -184,9 +184,9 @@ A structure can be completely erased - undefined - using the statement `undef`:
 undef( animals )
 ```
 **WARNING:**
-undef ( ) do not remove the structure it is aliasing, only undefine the alias used.
+undef ( ) does not remove the structure it is aliasing, only undefine the alias used.
 
-For example
+For example, consider:
 ```
 include "console.iol"
 
@@ -201,7 +201,7 @@ main {
 }
 ```
 
-running the code shows, that after the operation undef on p, the original data path is unchanged.
+Running the code shows that, after the operation undef on `p`, the original data path is unchanged.
 
 ## `<<` - copying an entire tree structure
 

--- a/web/language-tools-and-standard-library/basics/data_structures.md
+++ b/web/language-tools-and-standard-library/basics/data_structures.md
@@ -274,6 +274,48 @@ d
 
 Note that node `d.first` has been overwritten entirely by the subtree `s.first` which is defined as an empty node with four sub-nodes.
 
+## using literals
+
+You can create a custom data type from its literal specification.
+
+Consider the following structure
+
+```jolie
+d - 12
+|_ greeting = "hello"
+|_ first = "to the"
+    |_ first.second = "world"
+    |_ first.third = "!"
+```
+
+You can define d with the follow line:
+
+```jolie
+d << 12 {.greeting ="hello", .first = "to the", .first.second = "world", .first.third="!" }
+```
+**Warning:**
+Remember to use << to copy the entire tree structure.
+
+It's very common to make the mistake
+
+```jolie
+d = 12 {.greeting ="hello", .first = "to the", .first.second = "world", .first.third="!" }
+```
+
+In this case only the root value (12) would be assigned to d
+
+**Using the literals in calling the service's operation**
+
+You can use the literals calling an operation's service.
+
+So if we have the operation op at Service that allow a custom data type structure as d, defined above, we can call the operation in the follow mode
+
+```jolie
+op@Service(12 {.greeting ="hello", .first = "to the", .first.second = "world", .first.third="!" })()
+```
+
+
+
 ## `->` - structures aliases
 
 A structure element can be an alias, i.e. it can point to another variable path.

--- a/web/language-tools-and-standard-library/basics/data_structures.md
+++ b/web/language-tools-and-standard-library/basics/data_structures.md
@@ -318,3 +318,37 @@ two
 three
 ```
 
+**BEWARE OF ->:**
+a -> b
+
+where b is a custom data type,is a lazy reference not a pointer to the node.
+The espression on the right of -> will be evaluated evaluated every time you are going to use the reference a.
+So we could say a is a lazy reference.
+
+Consider the following use:
+
+```jolie
+define push_env {
+    __name = "env-" + __deepStack
+    ;
+    prev_env -> __environment.(__name)
+    ;
+    __deepStack++
+    ;
+    __name = "env-" + __deepStack
+    ;
+    __environment.(__name) = __name
+    ;
+    env -> __environment.(__name)
+}
+```
+
+the idea is to have ``` __environment``` as a root where every child variable represent an environment of execution.
+
+if we evaluate ```prev_env``` and ```env``` at the end of the routine we will find that they have the same value.
+
+```prev_env``` is evaluated as ``` __environment.(__name)```
+
+same expression of ``` env``` .
+
+If you are going to use static path (not dynamic) this type of problem will not arise, but if you are using dynamic look-up be careful of the type of implementation.

--- a/web/language-tools-and-standard-library/basics/data_structures.md
+++ b/web/language-tools-and-standard-library/basics/data_structures.md
@@ -183,7 +183,7 @@ A structure can be completely erased - undefined - using the statement `undef`:
 ```jolie
 undef( animals )
 ```
-**WARNING:**
+**Note that:**
 undef ( ) does not remove the structure it is aliasing, only undefine the alias used.
 
 For example, consider:
@@ -274,9 +274,9 @@ d
 
 Note that node `d.first` has been overwritten entirely by the subtree `s.first` which is defined as an empty node with four sub-nodes.
 
-## using literals
+## Using literals
 
-You can create a custom data type from its literal specification.
+You can create a custom data value from its literal specification.
 
 Consider the following structure
 
@@ -293,7 +293,7 @@ You can define d with the follow line:
 ```jolie
 d << 12 {.greeting ="hello", .first = "to the", .first.second = "world", .first.third="!" }
 ```
-**Warning:**
+**Note that:**
 Remember to use << to copy the entire tree structure.
 
 It's very common to make the mistake

--- a/web/language-tools-and-standard-library/basics/interfaces/data_types.md
+++ b/web/language-tools-and-standard-library/basics/interfaces/data_types.md
@@ -32,9 +32,41 @@ Basic data types can be refined in order to restrict the valid values. Depending
 | *string*     | length, regex, enum   |
 | *int*        | ranges                |
 | *long*       | ranges                |
-| *double*     | ranges                | 
+| *double*     | ranges                |
 
 When a value that does not respect the refinement type is forced to be used a *TypeMismatch* will be raised by the interpreter.
+
+#### String format
+
+The string is enclosed (as in other languages) by two double quote. 
+Inside the string you can 
+
++ use a single quote;
++ insert a special character with the usual escape method (\\<character>,  example \n")
++ using a double quote, escaping it (\"")
+
+You can split the string over multiple lines
+
+```jolie
+jsonValue = "{
+	\"int\": 123,
+	\"bool\": true,
+	\"long\": 124,
+	\"double\": 123.4,
+	\"string\": \"string\",
+	\"void\": {},
+	\"array\": [123, true,\"ciccio\",124,{}],
+	\"obj\" : {
+		\"int\": 1243,
+		\"bool\": true,
+		\"long\": 1234,
+		\"double\": 1234.4,
+		\"string\": \"string\",
+		\"void\": {}
+		}
+	}"
+;
+```
 
 #### Refinement: length
 This refinement allows for specifying the minimum and the maximum length of a string. The minimum and the maximum length must be specify as a couple of values between square brackets. Example:

--- a/web/language-tools-and-standard-library/basics/modules.md
+++ b/web/language-tools-and-standard-library/basics/modules.md
@@ -71,6 +71,7 @@ interface MyServiceInterface {
 
 service MyService( MyServiceParam: p ) {
 	
+	execution {concurrent}
 	inputPort IP {
 		location: p.location
 		protocol: p.protocol
@@ -170,7 +171,7 @@ service MyService{
 ```
 
 The section of the documentation dedicated to the [standard library](../standard-library-api/) reports more information on the modules, types, and interfaces available to programmers with the standard Jolie installation.
- 
+
 
 ## Debugging the import system
 
@@ -179,7 +180,7 @@ The import statement executes in three stages:
 - modules lookup;
 - modules parsing;
 - symbol binding. 
- 
+
 For each import statement, the Jolie interpreter resolves the import as specified in the module path, performing a lookup to the importing source.
 
 The source code of the imported target is then parsed and the symbol definitions are bound to the local execution environment.

--- a/web/language-tools-and-standard-library/basics/modules.md
+++ b/web/language-tools-and-standard-library/basics/modules.md
@@ -72,6 +72,7 @@ interface MyServiceInterface {
 service MyService( MyServiceParam: p ) {
 	
 	execution {concurrent}
+	
 	inputPort IP {
 		location: p.location
 		protocol: p.protocol
@@ -87,6 +88,8 @@ service MyService( MyServiceParam: p ) {
 ```
 
 The service `MyService` requires a value of type `MyServiceParam` for its execution. Specifically, the values in the parameter include the location and protocol of the `inputPort` and the multiplicative factor used in the `multiply` operation.
+
+Remember to indicate the execution mode, otherwise it would be single (single execution) giving rise to an exception in a calling sequence.
 
 ### Service execution target
 

--- a/web/language-tools-and-standard-library/standard-library-api/string_utils.md
+++ b/web/language-tools-and-standard-library/standard-library-api/string_utils.md
@@ -1,4 +1,8 @@
 # StringUtils
+Inclusion file:
+
+include "string_utils.iol" 
+from string_utils import StringUtils
 
 Inclusion code: 
 
@@ -74,7 +78,7 @@ Type: string
 
 ### valueToPrettyString <a id="valueToPrettyString"></a>
 
-Operation documentation: checks if the passed string starts with a given prefix
+Operation documentation: take a custom data type / simple type and return it's literal indented representation (string) 
 
 Invocation template:
 

--- a/web/language-tools-and-standard-library/web-applications/leonardo.md
+++ b/web/language-tools-and-standard-library/web-applications/leonardo.md
@@ -87,8 +87,8 @@ main
 {
     // existing code in Leonardo
     [ length( request )( response ){
-        response = 0;
-        for( i = 0, i
+        response = #request.item }]
+        ....
 ```
 
 The code above iterates over all the received items and sums their lengths.


### PR DESCRIPTION
web/language-tools-and-standard-library/basics/modules.md

In the example, there is not an indication of the execution.

Inserted the execution and some ending remarks.

----- ISSUE: #51

web/language-tools-and-standard-library/basics/data_structures

----- ISSUE: #50

web/language-tools-and-standard-library/standard-library-api/string_utils.html#valueToPrettyString

added initial section

Inclusion file:

include "string_utils.iol" 
from string_utils import StringUtils

I think this section could be inserted in all standard-library files, to indicate clearly the need to include/import the name of the file.

----- ISSUE: #49

web/language-tools-and-standard-library/basics/constants.md

Inserted section Comments.
I suggest renaming the file in Constants-Comments

----- ISSUE: #47

web/language-tools-and-standard-library/basics/data_structures.md

inserted at the end of file a new paragraph "Beware of ->"

----- ISSUE: #46

web/language-tools-and-standard-library/basics/data_structures.md

inserted paragraph using literals

----- ISSUE: #46

web/language-tools-and-standard-library/basics/interfaces/data_types.md

----- ISSUE: #44

web/language-tools-and-standard-library/basics/interfaces/data_types.md

Inserted paragraph "String format"

----- ISSUE: #41
web/language-tools-and-standard-library/web-applications/leonardo.md

The previous code for length was incomplete.
Changed the code to be complete

I'm going to close the issues associated with this pull request.




